### PR TITLE
add check for sudo and doas

### DIFF
--- a/signNodes.sh
+++ b/signNodes.sh
@@ -3,6 +3,26 @@
 # Store the command in a variable
 tsBinary=$(which tailscale)
 
+# Check if root and whether to use sudo or doas
+	CAN_ROOT=
+	SUDO=
+	if [ "$(id -u)" = 0 ]; then
+		CAN_ROOT=1
+		SUDO=""
+	elif type sudo >/dev/null; then
+		CAN_ROOT=1
+		SUDO="sudo"
+	elif type doas >/dev/null; then
+		CAN_ROOT=1
+		SUDO="doas"
+	fi
+	if [ "$CAN_ROOT" != "1" ]; then
+		echo "This installer needs to run commands as root."
+		echo "We tried looking for 'sudo' and 'doas', but couldn't find them."
+		echo "Either re-run this script as root, or set up sudo/doas."
+		exit 1
+	fi
+
 # Prompt the user to confirm that they want to sign all nodes
 printf "Do you want to sign all Mullvad nodes?\n"
 printf "Y/y to confirm: "
@@ -24,7 +44,7 @@ if [ "$choice0" = "Y" ] || [ "$choice0" = "y" ]; then
     nodeName=$(echo "$node" | jq -r .Name)
     if echo "$nodeName" | grep -q "^$country.*mullvad\.ts\.net\.$"; then
       printf "Signing node %s\n" "$nodeName"
-      $tsBinary lock sign $(echo "$node" | jq -r '.NodeKey')
+      $SUDO "$tsBinary" lock sign "$(echo "$node" | jq -r '.NodeKey')"
     else
       # If verbose logging is enabled, show skipped nodes
       if [ "$1" = "-v" ]; then


### PR DESCRIPTION
Yoinked the sudo checking from the [tailscale installer script](https://github.com/tailscale/tailscale/blob/main/scripts/installer.sh). Checks if running as root and whether to use sudo or doas if not. Prepends the signing commands with the appropriate command.


Fixes #4 