### PR TITLE
Change shebang to use env for bash

### DIFF
--- a/signNodes.sh
+++ b/signNodes.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
 # Store the command in a variable
 tsBinary=$(which tailscale)


### PR DESCRIPTION
Uses /usr/bin/env bash to run bash rather than /bin/bash as it is more compatible with more systems and to make compliant with best practice.