### PR TITLE
Clarify script wording

### DIFF
--- a/signNodes.ps1
+++ b/signNodes.ps1
@@ -1,6 +1,6 @@
 $tsBinary = Get-Command -Name tailscale
 
-Write-Output "Do you want to sign all Mullvad nodes?"
+Write-Output "Do you want to sign multiple Mullvad nodes?"
 $choice0 = Read-Host "Y/y to confirm: "
 
 if ($choice0 -eq "Y" -or $choice0 -eq "y") {

--- a/signNodes.sh
+++ b/signNodes.sh
@@ -23,8 +23,8 @@ tsBinary=$(which tailscale)
 		exit 1
 	fi
 
-# Prompt the user to confirm that they want to sign all nodes
-printf "Do you want to sign all Mullvad nodes?\n"
+# Prompt the user to confirm that they want to sign multiple nodes
+printf "Do you want to sign multiple Mullvad nodes?\n"
 printf "Y/y to confirm: "
 read -r choice0
 printf "\n" # To move to a new line after input


### PR DESCRIPTION
Adjusts the wording to avoid giving the user the impression that running the script always signs *all* nodes. For a user only signing specific country nodes this is less likely to cause confusion.